### PR TITLE
fix: oom errors during multi-vector evaluation

### DIFF
--- a/src/vidore_benchmark/retrievers/jina_v4_retriever.py
+++ b/src/vidore_benchmark/retrievers/jina_v4_retriever.py
@@ -105,7 +105,7 @@ class JinaV4Retriever(BaseVisionRetriever):
     def score_multi_vector(
         qs: List[torch.Tensor],
         ps: List[torch.Tensor],
-        batch_size: int = 128,
+        batch_size: int = 16,
         device: Optional[Union[str, torch.device]] = None,
     ) -> torch.Tensor:
         """

--- a/src/vidore_benchmark/retrievers/jina_v4_retriever.py
+++ b/src/vidore_benchmark/retrievers/jina_v4_retriever.py
@@ -72,7 +72,7 @@ class JinaV4Retriever(BaseVisionRetriever):
         if self.vector_type == "single_vector":
             return self.score_single_vector(query_embeddings, passage_embeddings, device=self.device)
         elif self.vector_type == "multi_vector":
-            return self.score_multi_vector(query_embeddings, passage_embeddings, device=self.device)
+            return self.score_multi_vector(query_embeddings, passage_embeddings, device=self.device, batch_size=batch_size)
         else:
             raise ValueError('vector_type must be one of the following: [`single_vector`, `multi_vector`]')
 
@@ -105,7 +105,7 @@ class JinaV4Retriever(BaseVisionRetriever):
     def score_multi_vector(
         qs: List[torch.Tensor],
         ps: List[torch.Tensor],
-        batch_size: int = 16,
+        batch_size: int = 128,
         device: Optional[Union[str, torch.device]] = None,
     ) -> torch.Tensor:
         """


### PR DESCRIPTION
We had problems with OOM errors because of too high batch size during late interaction retrieval when using high resolution values. It turned out that the score batch size provided as the argument `--batch-score` did not get passed to the score function. Instead 128 was used by default. This PR fixes this issue.